### PR TITLE
Revert "Enable Task Placement Constraints"

### DIFF
--- a/lib/hako/schedulers/ecs.rb
+++ b/lib/hako/schedulers/ecs.rb
@@ -481,11 +481,6 @@ module Hako
           },
           count: 1,
           started_by: 'hako oneshot',
-          placement_constraints: [
-            {
-              type: 'distinctInstance',
-            },
-          ],
         )
         result.failures.each do |failure|
           Hako.logger.error("#{failure.arn} #{failure.reason}")


### PR DESCRIPTION
ECSはデフォルトでタスクの振り分けがランダムとなっており、一部のコンテナインスタンスにタスクが偏ってしまうため、TaskPlacementConstraintsのdistinctInstanceを利用していた。
しかし、distinctInstanceは全コンテナインスタンスに平等にタスクを振り分けてくれるが、それぞれ1つずつしかタスクを実行してくれないため、意図していた挙動ではなかった。

このままでは実行するタスク数分のコンテナインスタンスが必要となってしまうため、一旦無効化したい。