### PR TITLE
Enable json formatted log

### DIFF
--- a/lib/hako.rb
+++ b/lib/hako.rb
@@ -9,6 +9,9 @@ module Hako
         $stdout.sync = true
         Logger.new($stdout).tap do |l|
           l.level = Logger::INFO
+          l.formatter = proc do |severity, datetime, progname, message|
+            %({"severity":"#{severity}","datetime":"#{datetime}","progname":"#{progname}","message":"#{message}"})
+          end
         end
       end
   end

--- a/lib/hako.rb
+++ b/lib/hako.rb
@@ -10,7 +10,7 @@ module Hako
         Logger.new($stdout).tap do |l|
           l.level = Logger::INFO
           l.formatter = proc do |severity, datetime, progname, message|
-            %({"severity":"#{severity}","datetime":"#{datetime}","progname":"#{progname}","message":"#{message}"})
+            %({"severity":"#{severity}","datetime":"#{datetime}","progname":"#{progname}","message":"#{message}"}\n)
           end
         end
       end

--- a/lib/hako.rb
+++ b/lib/hako.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require 'json'
 require 'logger'
 require 'hako/version'
 
@@ -10,7 +11,12 @@ module Hako
         Logger.new($stdout).tap do |l|
           l.level = Logger::INFO
           l.formatter = proc do |severity, datetime, progname, message|
-            %({"severity":"#{severity}","datetime":"#{datetime}","progname":"#{progname}","message":"#{message}"}\n)
+            {
+              severity: severity,
+              datetime: datetime,
+              progname: progname,
+              message: message
+            }.to_json << "\n"
           end
         end
       end


### PR DESCRIPTION
## 経緯
dockerでhakoを動かし、log-driverにawslogsを指定することでCloudWatchLogsのサブスクリプションフィルターからhakoのエラーログをLambdaでSlackに通知している。
その際にサブスクリプションフィルターのフィルター構文では、json形式のログでないとor演算やand演算が使えない。

そのため、ログのフォーマットをjsonにしたい。

## 参考
https://docs.aws.amazon.com/ja_jp/AmazonCloudWatch/latest/logs/FilterAndPatternSyntax.html#d0e4083