### PR TITLE
Output unhandled exceptions with logger

### DIFF
--- a/exe/hako
+++ b/exe/hako
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 require 'hako/cli'
-require 'english'
+require 'English'
 
 at_exit do
   Hako.logger.error $ERROR_INFO if $ERROR_INFO

--- a/exe/hako
+++ b/exe/hako
@@ -1,5 +1,10 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 require 'hako/cli'
+require 'english'
+
+at_exit do
+  Hako.logger.error $ERROR_INFO if $ERROR_INFO
+end
 
 Hako::CLI.start(ARGV)


### PR DESCRIPTION
jsonフォーマットのログを出力することにしたが、例外が起きたときはloggerを通さないためjsonフォーマットではなくなってしまう。

やりたいのは「CloudWatchLogsのサブスクリプションフィルターによるエラーの通知」であるため、例外時のエラーログもjsonフォーマットで出力しないといけない。

at_exitを使って、終了時に`$ERROR_INFO`があればエラー出力をするようにした。

## 参考
* [module function Kernel.#at_exit (Ruby 2.4.0)](https://docs.ruby-lang.org/ja/latest/method/Kernel/m/at_exit.html)