### PR TITLE
Use ECS TaskPlacementStrategy with spread

### DIFF
--- a/lib/hako/schedulers/ecs.rb
+++ b/lib/hako/schedulers/ecs.rb
@@ -481,6 +481,12 @@ module Hako
           },
           count: 1,
           started_by: 'hako oneshot',
+          placement_strategy: [
+            {
+              type: 'spread',
+              field: 'instanceId',
+            },
+          ],
         )
         result.failures.each do |failure|
           Hako.logger.error("#{failure.arn} #{failure.reason}")


### PR DESCRIPTION
現在のサーバー構成では、c4.large のインスタンス (メモリが 3.75GB) にメモリの hard limit を 2G, soft limit を 1.3 GB でタスクを実行しているため、2つのタスクがメモリ 2GB までつかうと OOM Killer が発動してしまう。

インスタンスタイプはあまり上げたくないので、タスクの配置戦略によって対策をする。

ECS はデフォルトでランダムにコンテナを配置してしまうため、コンテナインスタンスに余裕があっても、タスクが偏ってしまい、リソースに無駄が生じる。

そのため、タスクを分散して配置させることで用意してあるコンテナインスタンスを均等に使わせ、 OOM Killer が発動する確率を下げる。

(別途 swap file を使うことで最悪のケースが起きた場合の対策も行っている)

## 補足

[hako v0.25.0](https://github.com/eagletmt/hako/tree/v0.25.0) から TaskPlacementStrategy をサポートしているが、
このリポジトリの master に取り込むのは差分が多くて確認に手間がかかるのでひとまず、ハードコーディングした TaskPlacementStrategy による spread を導入する。