### PR TITLE
Count only instances in non-DRAINING state

### DIFF
--- a/lib/hako/schedulers/ecs.rb
+++ b/lib/hako/schedulers/ecs.rb
@@ -739,7 +739,9 @@ module Hako
         container_instances.any? do |ci|
           cpu = ci.remaining_resources.find { |r| r.name == 'CPU' }.integer_value
           memory = ci.remaining_resources.find { |r| r.name == 'MEMORY' }.integer_value
-          required_cpu < cpu && required_memory < memory
+          # https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/ECS/Types/ContainerInstance.html#status-instance_method
+          status = ci.status # ACTIVE or INACTIVE or DRAINING
+          required_cpu < cpu && required_memory < memory && status != 'DRAINING' # exclude instances in DRAINING state
         end
       end
     end


### PR DESCRIPTION
connects to feedforce/datafeed-maker#5966

# 変更点

インスタンスのキャパシティチェック時に、statusが DRAINING なものは除外するようにした。

# 動作確認

## datafeed-maker にて

1. 本ブランチのhakoを使ったコンテナイメージを作成する  
  タグ: sakuro_hako-non-draining で作成済みだが、[自分で作る](https://github.com/feedforce/hako/pull/7#issuecomment-448099303)ところから行なってもよい。  
[hako-non-drainingブランチ](https://github.com/feedforce/datafeed-maker/tree/hako-non-draining) を参照(マージしない)
1. lib/tasks/aws/job_kicker.rake と lib/tasks/aws/sandbox.rake の `@tag` の値を、前ステップのタグに書き換える
1. job_kicker / sandbox 環境を起動する  
    sandbox の状態: 2インスタンス(ACTIVE(daemon) / ACTIVE(none))

## AWSコンソールにて

1. ACTIVE(none) のインスタンスを DRAINING にする  
    sandbox の状態: 2インスタンス(ACTIVE(daemon) / DRAINING(none))
1. オートスケーリンググループの max を +1 して、増やせるようにする。 (desired は変更しない)

## infra-df-maker/serverless にて

1.  sample/sample_sleep を起動
    ```
    echo '{ "cluster": "sandbox-'$USER'", "data_supplier": "sample", "publisher": "sample_sleep" }' |
        node_modules/.bin/sls invoke local -f ecsRunTask -s $USER
    ```
    sandbox の状態: 2インスタンス(ACTIVE(daemon, batch) / DRAINING(none))
1.  起動したタスクが動いている間に、もう1つ sample/sample_sleep を起動
1. オートスケーリングでインスタンスが1台増える
1. 増えたインスタンスで2つめの sample/sample_sleep が動く  
    sandbox の状態: 3インスタンス(ACTIVE(daemon, batch) / DRAINING(none) / ACTIVE(batch))

## datafeed-maker にて

1. job_kicker / sandbox 環境を終了する

# マージ条件

* [x] @azmin8744 のLGTM