### PR TITLE
No need to mind daemon service already

### DIFF
--- a/lib/hako/schedulers/ecs.rb
+++ b/lib/hako/schedulers/ecs.rb
@@ -751,16 +751,6 @@ module Hako
           desired = current + 1
           Hako.logger.info("Increment desired_capacity of #{asg.auto_scaling_group_name} from #{current} to #{desired}")
           autoscaling.set_desired_capacity(auto_scaling_group_name: asg.auto_scaling_group_name, desired_capacity: desired)
-          Hako.logger.info("Optimize desired_count of service to #{desired / 2}")
-          ecs_client.update_service(
-            cluster: @cluster,
-            service: 'daemon',
-            desired_count: desired / 2,
-            deployment_configuration: {
-              maximum_percent: 200,
-              minimum_healthy_percent: 100,
-            },
-          )
         end
       end
 


### PR DESCRIPTION
## 背景

スケールアウト時に `daemon` サービスも名指しでサービス定義を更新していたが、 `daemon` サービスそのものが無くなったので不要になった。

## やったこと

`daemon` サービスを更新する処理を削除した